### PR TITLE
Fix #1 Preserve MDC context, output it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>io.github.dibog</groupId>
     <artifactId>cloudwatch-logback-appender</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
 
 	<name>cloudwatch-logback-appender</name>
 	<description>Logback Appender which uses stores the log entries in ASW Cloudwatch logs.</description>

--- a/src/main/java/io/github/dibog/AwsLogAppender.java
+++ b/src/main/java/io/github/dibog/AwsLogAppender.java
@@ -71,6 +71,7 @@ public class AwsLogAppender extends AppenderBase<ILoggingEvent> {
 
         AwsCWEventDump queue = dump;
         if (dump != null) {
+            event.prepareForDeferredProcessing();
             dump.queue(event);
         }
 

--- a/src/main/java/io/github/dibog/LoggingEventToStringImpl.java
+++ b/src/main/java/io/github/dibog/LoggingEventToStringImpl.java
@@ -46,6 +46,11 @@ class LoggingEventToStringImpl implements LoggingEventToString {
             values.put("exception", ExceptionUtil.toString(exceptionProxy));
         }
 
+        // In theory, event.getMDCPropertyMap() should not be null, in practice it can
+        if (event.getMDCPropertyMap() != null && !event.getMDCPropertyMap().isEmpty()) {
+            values.put("context", event.getMDCPropertyMap());
+        }
+
         try {
             return m.writeValueAsString(values);
         }

--- a/src/test/java/io/github/dibog/Main.java
+++ b/src/test/java/io/github/dibog/Main.java
@@ -2,10 +2,14 @@ package io.github.dibog;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.sql.SQLException;
 
 public class Main {
+
+    private static final int QUEUE_LEN = 100;
+
     public static Exception makeNestedException() {
 
         SQLException e = new SQLException("Some message");
@@ -21,13 +25,31 @@ public class Main {
     }
 
     public static void main(String[] args) throws InterruptedException {
+        testLog();
+        //testMDC();
+    }
+
+    public static void testLog() throws InterruptedException {
         Logger logger = LoggerFactory.getLogger(Main.class);
 
-        for(int i=0; i<200; ++i) {
+        for(int i=0; i<2*QUEUE_LEN; ++i) {
             logger.info("Message {}", i);
 //            Thread.sleep(10_000L );
         }
 
+        Thread.sleep(20_000L);
+
+        System.out.println("### Done");
+    }
+
+    public static void testMDC() throws InterruptedException {
+        MDC.put("customer_name", "Jon Snow");
+        Logger logger = LoggerFactory.getLogger(Main.class);
+        // HOW TO TEST: Set breakpoint at the end of io.github.dibog.LoggingEventToStringImpl.map,
+        // check that the values written include the MDC key
+        for (int i=0; i<200; ++i) {
+            logger.info("This message should be logged together with the given MDC");
+        }
         Thread.sleep(20_000L);
 
         System.out.println("### Done");


### PR DESCRIPTION
Fix #1 Preserve MDC context, output it

To test - modify `Main.main` to run `testMDC()`, follow the instructions in the comment
in the method.