### PR TITLE
Create version of logback appender with AWS SDK v2 dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,9 @@
 	</developers>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <awssdk2.version>2.5.15</awssdk2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
+ <!--
   ~ Copyright 2018  Dieter Bogdoll
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@
 
     <groupId>io.github.dibog</groupId>
     <artifactId>cloudwatch-logback-appender</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
 
 	<name>cloudwatch-logback-appender</name>
 	<description>Logback Appender which uses stores the log entries in ASW Cloudwatch logs.</description>
@@ -48,23 +48,11 @@
 	</developers>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <aws.version>1.11.292</aws.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <awssdk2.version>2.5.15</awssdk2.version>
         <logback.version>1.2.3</logback.version>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-bom</artifactId>
-                <version>${aws.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
 
@@ -75,8 +63,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-logs</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>cloudwatchlogs</artifactId>
+            <version>${awssdk2.version}</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,21 @@
         <plugins>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                        <arg>-Xlint:deprecation</arg>
+                        <arg>-Xlint:unchecked</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.2</version>
+                <version>3.0.0-M1</version>
                 <executions>
                     <execution>
                         <id>default-deploy</id>

--- a/src/main/java/io/github/dibog/AwsCWEventDump.java
+++ b/src/main/java/io/github/dibog/AwsCWEventDump.java
@@ -20,8 +20,14 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggerContextVO;
 import ch.qos.logback.core.Layout;
 import ch.qos.logback.core.spi.ContextAware;
-import com.amazonaws.services.logs.AWSLogs;
-import com.amazonaws.services.logs.model.*;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsResponse;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogStreamsResponse;
+import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
+import software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup;
+import software.amazon.awssdk.services.cloudwatchlogs.model.LogStream;
+import software.amazon.awssdk.services.cloudwatchlogs.model.OperationAbortedException;
+import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsRequest;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -39,20 +45,20 @@ class AwsCWEventDump implements Runnable {
     private final DateFormat dateFormat;
     private final ContextAware logContext;
     private final Date dateHolder = new Date();
-    private final PutLogEventsRequest logEventReq;
+    private final PutLogEventsRequest.Builder logEventReq;
 
     private volatile boolean done = false;
 
-    private AWSLogs awsLogs;
+    private CloudWatchLogsClient awsLogs;
     private String currentStreamName = null;
     private String nextToken = null;
 
-    public AwsCWEventDump( AwsLogAppender aAppender ) {
+    public AwsCWEventDump( final AwsLogAppender aAppender ) {
         logContext = requireNonNull(aAppender, "appender");
         awsConfig = aAppender.awsConfig==null ? new AwsConfig(): aAppender.awsConfig;
         createLogGroup = aAppender.createLogGroup;
         groupName = requireNonNull(aAppender.groupName, "appender.groupName");
-        logEventReq = new PutLogEventsRequest().withLogGroupName(groupName);
+        logEventReq = PutLogEventsRequest.builder().logGroupName(groupName);
         streamName = requireNonNull(aAppender.streamName, "appender.streamName");
 
         if(aAppender.layout==null) {
@@ -60,12 +66,7 @@ class AwsCWEventDump implements Runnable {
         }
         else {
             final Layout<ILoggingEvent> delegate = aAppender.layout;
-            layout = new LoggingEventToString() {
-                @Override
-                public String map(ILoggingEvent event) {
-                    return delegate.doLayout(event);
-                }
-            };
+            layout = event -> delegate.doLayout(event);
         }
 
         if(aAppender.dateFormat==null || aAppender.dateFormat.trim().isEmpty()) {
@@ -80,13 +81,13 @@ class AwsCWEventDump implements Runnable {
         currentStreamName = null;
     }
 
-    private void openStream(String aNewStreamName) {
+    private void openStream(final String aNewStreamName) {
 
         if(awsLogs==null) {
             try {
-                awsLogs = awsConfig.createAWSLogs();
+                awsLogs = awsConfig.createAwsLogs();
             }
-            catch(Exception e) {
+            catch(final Exception e) {
                 logContext.addError("Exception while opening AWSLogs. Shutting down the cloud watch logger.", e);
                 shutdown();
             }
@@ -96,61 +97,56 @@ class AwsCWEventDump implements Runnable {
             if (findLogGroup(groupName)==null) {
                 logContext.addInfo("creating log group '"+groupName+"'");
                 try {
-                    awsLogs.createLogGroup(new CreateLogGroupRequest(groupName));
+                    awsLogs.createLogGroup( r -> r.logGroupName(groupName));
                 }
-                catch(OperationAbortedException e) {
+                catch(final OperationAbortedException e) {
                     logContext.addError("couldn't create log group '"+groupName+"': "+e.getLocalizedMessage());
                 }
             }
         }
 
-        LogStream stream = findLogStream(groupName, aNewStreamName);
+        final LogStream stream = findLogStream(groupName, aNewStreamName);
         if(stream==null) {
             try {
                 logContext.addInfo("creating log stream '"+streamName+"'");
-                awsLogs.createLogStream(new CreateLogStreamRequest(groupName, aNewStreamName));
+                awsLogs.createLogStream(r -> r.logGroupName(groupName).logStreamName(aNewStreamName));
             }
-            catch(Exception e) {
+            catch(final Exception e) {
                 logContext.addError("Exception while creating log stream ( "+groupName+" / "+aNewStreamName+" ). Shutting down the cloud watch logger.", e);
                 shutdown();
             }
             nextToken = null;
         }
         else {
-            nextToken = stream.getUploadSequenceToken();
+            nextToken = stream.uploadSequenceToken();
         }
 
-        logEventReq.withLogStreamName(aNewStreamName);
+        logEventReq.logStreamName(aNewStreamName);
         currentStreamName = aNewStreamName;
 
     }
 
-    private LogGroup findLogGroup(String aName) {
-        DescribeLogGroupsResult result = awsLogs.describeLogGroups(
-                new DescribeLogGroupsRequest()
-                        .withLogGroupNamePrefix(groupName)
-        );
-        for (LogGroup group : result.getLogGroups()) {
-            if (group.getLogGroupName().equals(aName)) {
+    private LogGroup findLogGroup(final String aName) {
+        final DescribeLogGroupsResponse result = awsLogs.describeLogGroups(r -> r.logGroupNamePrefix(groupName));
+        for (final LogGroup group : result.logGroups()) {
+            if (group.logGroupName().equals(aName)) {
                 return group;
             }
         }
         return null;
     }
 
-    private LogStream findLogStream(String aGroupName, String aStreamName) {
+    private LogStream findLogStream(final String aGroupName, final String aStreamName) {
         try {
-            DescribeLogStreamsResult result = awsLogs.describeLogStreams(
-                    new DescribeLogStreamsRequest(groupName)
-                            .withLogStreamNamePrefix(aStreamName)
-            );
-            for (LogStream stream : result.getLogStreams()) {
-                if (stream.getLogStreamName().equals(aStreamName)) {
+            final DescribeLogStreamsResponse result = awsLogs.describeLogStreams(r -> r.logGroupName(groupName).logStreamNamePrefix(aStreamName));
+
+            for (final LogStream stream : result.logStreams()) {
+                if (stream.logStreamName().equals(aStreamName)) {
                     return stream;
                 }
             }
         }
-        catch(Exception e) {
+        catch(final Exception e) {
             logContext.addError("Exception while trying to describe log stream ( "+aGroupName+"/"+aStreamName+" ).  Shutting down the cloud watch logger.", e);
             shutdown();
         }
@@ -158,10 +154,10 @@ class AwsCWEventDump implements Runnable {
         return null;
     }
 
-    private void log(Collection<ILoggingEvent> aEvents) {
+    private void log(final Collection<ILoggingEvent> aEvents) {
         if(dateFormat!=null) {
             dateHolder.setTime(System.currentTimeMillis());
-            String newStreamName = streamName + "-" + dateFormat.format(dateHolder);
+            final String newStreamName = streamName + "-" + dateFormat.format(dateHolder);
 
             if ( !newStreamName.equals(currentStreamName) ) {
                 logContext.addInfo("stream name changed from '"+currentStreamName+"' to '"+newStreamName+"'");
@@ -174,23 +170,27 @@ class AwsCWEventDump implements Runnable {
             openStream(streamName);
         }
 
-        Collection<InputLogEvent> events =  new ArrayList<>(aEvents.size());
-        for(ILoggingEvent event : aEvents) {
+        final Collection<InputLogEvent> events =  new ArrayList<>(aEvents.size());
+
+        for(final ILoggingEvent event : aEvents) {
+
             if(event.getLoggerContextVO()!=null) {
-                events.add(new InputLogEvent()
-                        .withTimestamp(event.getTimeStamp())
-                        .withMessage(layout.map(event)));
+                events.add(InputLogEvent.builder()
+                        .timestamp(event.getTimeStamp())
+                        .message(layout.map(event))
+                        .build());
             }
         }
 
         try {
             nextToken = awsLogs.putLogEvents(
                     logEventReq
-                            .withSequenceToken(nextToken)
-                            .withLogEvents(events)
-            ).getNextSequenceToken();
+                            .sequenceToken(nextToken)
+                            .logEvents(events)
+                            .build()
+            ).nextSequenceToken();
         }
-        catch(Exception e) {
+        catch(final Exception e) {
             logContext.addError("Exception while adding log events.", e);
         }
     }
@@ -199,30 +199,31 @@ class AwsCWEventDump implements Runnable {
         done = true;
     }
 
-    public void queue(ILoggingEvent event) {
+    public void queue(final ILoggingEvent event) {
         queue.put(event);
     }
 
+    @Override
     public void run() {
-        List<ILoggingEvent> collections = new LinkedList<ILoggingEvent>();
+        final List<ILoggingEvent> collections = new LinkedList<ILoggingEvent>();
         LoggerContextVO context = null;
         while(!done) {
 
             try {
-                int[] nbs = queue.drainTo(collections);
+                final int[] nbs = queue.drainTo(collections);
                 if(context==null && !collections.isEmpty()) {
                     context = collections.get(0).getLoggerContextVO();
                 }
 
-                int msgProcessed = nbs[0];
-                int msgSkipped = nbs[1];
+                final int msgProcessed = nbs[0];
+                final int msgSkipped = nbs[1];
                 if(context!=null && msgSkipped>0) {
                     collections.add(new SkippedEvent(msgSkipped, context));
                 }
                 log(collections);
                 collections.clear();
             }
-            catch(InterruptedException e) {
+            catch(final InterruptedException e) {
                 // ignoring
             }
         }

--- a/src/main/java/io/github/dibog/AwsConfig.java
+++ b/src/main/java/io/github/dibog/AwsConfig.java
@@ -16,50 +16,43 @@
 
 package io.github.dibog;
 
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.profile.ProfileCredentialsProvider;
-import com.amazonaws.services.logs.AWSLogs;
-import com.amazonaws.services.logs.AWSLogsClientBuilder;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClientBuilder;
 
 public class AwsConfig {
-    private ClientConfiguration clientConfig;
+
     private AwsCredentials credentials;
     private String profileName;
     private String region;
 
-    public void setCredentials(AwsCredentials credentials) {
+    public void setCredentials(final AwsCredentials credentials) {
         this.credentials = credentials;
     }
 
-    public void setClientConfig(ClientConfiguration clientConfig) {
-        this.clientConfig = clientConfig;
-    }
-
-    public void setRegion(String region) {
+    public void setRegion(final String region) {
         this.region = region;
     }
 
-    public void setProfileName(String profileName) {
+    public void setProfileName(final String profileName) {
         this.profileName = profileName;
     }
 
-    public AWSLogs createAWSLogs() {
-        AWSLogsClientBuilder builder = AWSLogsClientBuilder.standard();
+    public CloudWatchLogsClient createAwsLogs() {
 
-        if(region!=null) {
-            builder.withRegion(region);
+        final CloudWatchLogsClientBuilder builder = CloudWatchLogsClient.builder();
+
+        if(region != null) {
+            builder.region(Region.of(region));
         }
 
-        if(clientConfig!=null) {
-            builder.withClientConfiguration(clientConfig);
+        if(profileName != null) {
+            builder.credentialsProvider(ProfileCredentialsProvider.builder().profileName(profileName).build());
         }
-
-        if(profileName!=null) {
-            builder.withCredentials(new ProfileCredentialsProvider(profileName));
-        }
-        else if(credentials!=null) {
-            builder.withCredentials(new AWSStaticCredentialsProvider(credentials));
+        else if(credentials != null) {
+            builder.credentialsProvider(StaticCredentialsProvider.create(credentials));
         }
 
         return builder.build();

--- a/src/main/java/io/github/dibog/AwsCredentials.java
+++ b/src/main/java/io/github/dibog/AwsCredentials.java
@@ -16,32 +16,35 @@
 
 package io.github.dibog;
 
-import com.amazonaws.auth.AWSCredentials;
+public class AwsCredentials implements software.amazon.awssdk.auth.credentials.AwsCredentials {
 
-public class AwsCredentials implements AWSCredentials{
     private String accessKeyId;
     private String secretAccessKey;
+
+    @Override
+    public String accessKeyId() {
+        return accessKeyId;
+    }
+
+    @Override
+    public String secretAccessKey() {
+        return secretAccessKey;
+    }
 
     public String getAccessKeyId() {
         return accessKeyId;
     }
 
-    public void setAccessKeyId(String accessKeyId) {
+    public void setAccessKeyId(final String accessKeyId) {
         this.accessKeyId = accessKeyId;
     }
 
-    public void setSecretAccessKey(String secretAccessKey) {
+    public String getSecretAccessKey() {
+        return secretAccessKey;
+    }
+
+    public void setSecretAccessKey(final String secretAccessKey) {
         this.secretAccessKey = secretAccessKey;
     }
 
-    @Override
-    public String getAWSAccessKeyId() {
-        return accessKeyId;
-    }
-
-    @Override
-    public String getAWSSecretKey() {
-        return secretAccessKey;
-    }
 }
-

--- a/src/main/java/io/github/dibog/RingBuffer.java
+++ b/src/main/java/io/github/dibog/RingBuffer.java
@@ -33,8 +33,11 @@ class RingBuffer<E> {
     private int head = 0;
     private int size = 0;
 
-    public RingBuffer(int aCapacity) {
-        if(aCapacity<=0) throw new IllegalArgumentException("Capacity must be positive");
+    @SuppressWarnings("unchecked")
+    public RingBuffer(final int aCapacity) {
+        if(aCapacity<=0) {
+            throw new IllegalArgumentException("Capacity must be positive");
+        }
         cap = aCapacity;
         buffer = (E[])new Object[aCapacity];
     }
@@ -47,11 +50,11 @@ class RingBuffer<E> {
      * @return false if the item could be inserted without removing an old one
      *
      */
-    public boolean put(E aElement) {
+    public boolean put(final E aElement) {
         lock.lock();
 
         try {
-            E prev = buffer[head];
+            final E prev = buffer[head];
             buffer[head] = aElement;
 
             head++;
@@ -66,7 +69,7 @@ class RingBuffer<E> {
 
             empty.signalAll();
 
-            boolean overwritten = prev!=null;
+            final boolean overwritten = prev!=null;
             if(overwritten) {
                 skipped.incrementAndGet();
             }
@@ -77,7 +80,7 @@ class RingBuffer<E> {
         }
     }
 
-    private int inc(int current) {
+    private int inc(final int current) {
         assert 0<=current;
 
         int next = current+1;
@@ -94,7 +97,7 @@ class RingBuffer<E> {
      *
      * @return (nbOfMessageCollected, nbOfSkippedMessages)
      */
-    public int[] drainTo(Collection<E> aCollection) throws InterruptedException {
+    public int[] drainTo(final Collection<E> aCollection) throws InterruptedException {
         lock.lock();
         try {
 
@@ -113,7 +116,7 @@ class RingBuffer<E> {
                     index -= cap;
                 }
 
-                E elem = buffer[index];
+                final E elem = buffer[index];
                 assert elem!=null;
 
                 buffer[index]=null;

--- a/src/main/java/io/github/dibog/SkippedEvent.java
+++ b/src/main/java/io/github/dibog/SkippedEvent.java
@@ -28,7 +28,7 @@ class SkippedEvent implements ILoggingEvent {
     private final int no;
     private final LoggerContextVO loggerContextVO;
 
-    public SkippedEvent(int aMessages, LoggerContextVO aLoggerContextV0) {
+    public SkippedEvent(final int aMessages, final LoggerContextVO aLoggerContextV0) {
         no = aMessages;
         loggerContextVO = aLoggerContextV0;
     }
@@ -93,6 +93,7 @@ class SkippedEvent implements ILoggingEvent {
         return null;
     }
 
+    @Deprecated
     @Override
     public Map<String, String> getMdc() {
         return null;


### PR DESCRIPTION
Hi,

I am using AWS SDK v2 for some green-field projects, and thought it would be nice to to have the cloudwatch appender also use v2 dependencies.

For the appender it would mean maintaing/releasing two versions. (This should not be merged to master, but to some aws-v2 branch to be maintained in parallel with v1 stream.)

Note I could not figure out replacement for the ClientConfig, so I removed it for now. In AWS SDK v2 they (among other things) seem to have hidden the proxy overrides, etc, somewhere in http client config, but I was not able to find it.